### PR TITLE
Add initial mimic bot infrastructure and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,3 +485,6 @@ $RECYCLE.BIN/
 
 # OpenDAoC
 /Pathing/Detour/Build
+
+# Local dotnet installation directory
+.dotnet/

--- a/GameServer/ai/brain/Mimic/MimicBrain.cs
+++ b/GameServer/ai/brain/Mimic/MimicBrain.cs
@@ -1,0 +1,58 @@
+using DOL.AI.Brain;
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public class MimicBrain : FollowOwnerBrain
+    {
+        private readonly MimicNPC _mimic;
+        private bool _preventCombat;
+        private bool _pvpMode;
+        private GameLiving? _guardTarget;
+
+        public MimicBrain(GameLiving owner, MimicNPC mimic) : base(owner)
+        {
+            _mimic = mimic;
+        }
+
+        public override void Think()
+        {
+            base.Think();
+
+            if (_preventCombat)
+                return;
+
+            if (_guardTarget != null)
+            {
+                if (_guardTarget.ObjectState == GameObject.eObjectState.Active)
+                {
+                    if (!_mimic.IsWithinRadius(_guardTarget, 150))
+                        _mimic.Follow(_guardTarget, 120, 320);
+                    return;
+                }
+
+                _guardTarget = null;
+            }
+
+            if (Owner != null && !_mimic.IsWithinRadius(Owner, 350))
+            {
+                _mimic.Follow(Owner, 150, 350);
+            }
+        }
+
+        public void SetPreventCombat(bool value)
+        {
+            _preventCombat = value;
+        }
+
+        public void SetPvPMode(bool value)
+        {
+            _pvpMode = value;
+        }
+
+        public void SetGuardTarget(GameLiving? target)
+        {
+            _guardTarget = target;
+        }
+    }
+}

--- a/GameServer/commands/playercommands/m.cs
+++ b/GameServer/commands/playercommands/m.cs
@@ -1,0 +1,51 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&m",
+        ePrivLevel.Player,
+        "Summon a mimic by class",
+        "/m <classname> [level]")]
+    public sealed class MimicSummonSingleCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 2)
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            string className = args[1];
+            int level = client.Player.Level;
+            if (args.Length >= 3 && !int.TryParse(args[2], out level))
+            {
+                DisplayMessage(client, "Invalid level supplied.");
+                return;
+            }
+
+            MimicTemplate? template = MimicManager.FindTemplateByClass(className);
+            if (template == null)
+            {
+                DisplayMessage(client, "No mimic template matches that class.");
+                return;
+            }
+
+            try
+            {
+                MimicNPC mimic = MimicManager.CreateMimic(client.Player, template, level);
+                DisplayMessage(client, $"Summoned {mimic.Name} at level {mimic.Level}.");
+            }
+            catch (Exception ex)
+            {
+                DisplayMessage(client, $"Failed to summon mimic: {ex.Message}");
+            }
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mbattle.cs
+++ b/GameServer/commands/playercommands/mbattle.cs
@@ -1,0 +1,55 @@
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mbattle",
+        ePrivLevel.Player,
+        "Control mimic battleground events",
+        "/mbattle thid start",
+        "/mbattle thid stop",
+        "/mbattle thid clear")]
+    public sealed class MimicBattleCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 3)
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            string region = args[1].ToLowerInvariant();
+            if (region != "thid")
+            {
+                DisplayMessage(client, "Only the Thidranki region is supported.");
+                return;
+            }
+
+            string action = args[2].ToLowerInvariant();
+            switch (action)
+            {
+                case "start":
+                    MimicManager.SetBattleState(region, true);
+                    DisplayMessage(client, "Thidranki mimic battle started.");
+                    break;
+                case "stop":
+                    MimicManager.SetBattleState(region, false);
+                    DisplayMessage(client, "Thidranki mimic battle stopped.");
+                    break;
+                case "clear":
+                    MimicManager.SetBattleState(region, false);
+                    MimicManager.ClearAllMimics();
+                    DisplayMessage(client, "Thidranki mimics cleared.");
+                    break;
+                default:
+                    DisplaySyntax(client);
+                    break;
+            }
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mcamp.cs
+++ b/GameServer/commands/playercommands/mcamp.cs
@@ -1,0 +1,96 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mcamp",
+        ePrivLevel.Player,
+        "Manage mimic camp behavior",
+        "/mcamp set",
+        "/mcamp remove",
+        "/mcamp aggrorange <1-6000>",
+        "/mcamp filter <color>")]
+    public sealed class MimicCampCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 2)
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            string action = args[1].ToLowerInvariant();
+
+            switch (action)
+            {
+                case "set":
+                    SetCamp(client);
+                    break;
+                case "remove":
+                    MimicManager.ClearCamp(client.Player);
+                    DisplayMessage(client, "Mimic camp cleared. Returning to follow behavior.");
+                    break;
+                case "aggrorange":
+                    SetAggroRange(client, args);
+                    break;
+                case "filter":
+                    SetFilter(client, args);
+                    break;
+                default:
+                    DisplaySyntax(client);
+                    break;
+            }
+        }
+
+        private static void SetCamp(GameClient client)
+        {
+            Point3D ground = client.Player.GroundTarget;
+            if (ground == null || (ground.X == 0 && ground.Y == 0 && ground.Z == 0))
+            {
+                client.Out.SendMessage("Set a ground target first.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return;
+            }
+
+            MimicGroupState state = MimicManager.GetOrCreateGroupState(client.Player);
+            MimicManager.SetCamp(client.Player, new Point3D(ground), state.CampAggroRange, state.CampFilter);
+            client.Out.SendMessage($"Mimic camp set to {ground} with aggro range {state.CampAggroRange}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+        }
+
+        private static void SetAggroRange(GameClient client, string[] args)
+        {
+            if (args.Length < 3 || !int.TryParse(args[2], out int range))
+            {
+                client.Out.SendMessage("Provide a numeric aggro range between 1 and 6000.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return;
+            }
+
+            range = Math.Clamp(range, 1, 6000);
+            MimicManager.SetAggroRange(client.Player, range);
+            client.Out.SendMessage($"Mimic camp aggro range set to {range}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+        }
+
+        private static void SetFilter(GameClient client, string[] args)
+        {
+            if (args.Length < 3)
+            {
+                client.Out.SendMessage("Provide a con color filter.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return;
+            }
+
+            if (!MimicManager.TryParseConColor(args[2], out ConColor color))
+            {
+                client.Out.SendMessage("Unknown con color. Use grey, green, blue, yellow, orange, red, or purple.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return;
+            }
+
+            MimicManager.SetFilter(client.Player, color);
+            client.Out.SendMessage($"Mimic camp filter set to {color}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mgroup.cs
+++ b/GameServer/commands/playercommands/mgroup.cs
@@ -1,0 +1,67 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mgroup",
+        ePrivLevel.Player,
+        "Summon a group of mimics",
+        "/mgroup [realm] [amount] [level]")]
+    public sealed class MimicGroupCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            eRealm realm = client.Player.Realm;
+            int count = 8;
+            int level = client.Player.Level;
+
+            if (args.Length >= 2 && !Enum.TryParse(args[1], true, out realm))
+            {
+                DisplayMessage(client, "Unknown realm. Use Albion, Midgard, or Hibernia.");
+                return;
+            }
+
+            if (args.Length >= 3 && (!int.TryParse(args[2], out count) || count <= 0))
+            {
+                DisplayMessage(client, "Specify a positive amount.");
+                return;
+            }
+
+            if (args.Length >= 4 && !int.TryParse(args[3], out level))
+            {
+                DisplayMessage(client, "Invalid level specified.");
+                return;
+            }
+
+            var templates = MimicManager.GetTemplatesForRealm(realm);
+            if (templates.Count == 0)
+            {
+                DisplayMessage(client, "No mimic templates available for that realm.");
+                return;
+            }
+
+            int created = 0;
+            for (int i = 0; i < count; i++)
+            {
+                MimicTemplate template = templates[i % templates.Count];
+                try
+                {
+                    MimicManager.CreateMimic(client.Player, template, level);
+                    created++;
+                }
+                catch (Exception ex)
+                {
+                    DisplayMessage(client, $"Failed to summon {template.DisplayName}: {ex.Message}");
+                    break;
+                }
+            }
+
+            DisplayMessage(client, $"Summoned {created} mimics.");
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mguard.cs
+++ b/GameServer/commands/playercommands/mguard.cs
@@ -1,0 +1,53 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+using DOL.GS;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mguard",
+        ePrivLevel.Player,
+        "Order a mimic to guard a friendly target",
+        "/mguard",
+        "/mguard <name>")]
+    public sealed class MimicGuardCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            MimicNPC? mimic = client.Player.TargetObject as MimicNPC;
+            if (mimic == null)
+            {
+                DisplayMessage(client, "Target a mimic to assign guard duty.");
+                return;
+            }
+
+            GameLiving target = client.Player;
+            if (args.Length > 1)
+            {
+                string name = string.Join(' ', args, 1, args.Length - 1);
+                target = FindGuardTarget(client.Player, name) ?? target;
+            }
+
+            MimicManager.GuardTarget(mimic, target);
+            DisplayMessage(client, $"{mimic.Name} now guards {target.Name}.");
+        }
+
+        private static GameLiving? FindGuardTarget(GamePlayer player, string name)
+        {
+            if (player.Group != null)
+            {
+                foreach (GameLiving member in player.Group.GetMembersInTheGroup())
+                {
+                    if (member.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                        return member;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mlfg.cs
+++ b/GameServer/commands/playercommands/mlfg.cs
@@ -1,0 +1,69 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mlfg",
+        ePrivLevel.Player,
+        "Display available mimic recruits or invite one by index",
+        "/mlfg",
+        "/mlfg <index>")]
+    public sealed class MimicLookingForGroupCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length <= 1)
+            {
+                ShowTemplates(client);
+                return;
+            }
+
+            if (!int.TryParse(args[1], out int index))
+            {
+                DisplayMessage(client, "Invalid index.");
+                return;
+            }
+
+            var templates = MimicManager.GetTemplatesForPlayer(client.Player);
+            if (index < 0 || index >= templates.Count)
+            {
+                DisplayMessage(client, "Index out of range.");
+                return;
+            }
+
+            MimicTemplate template = templates[index];
+
+            try
+            {
+                MimicNPC mimic = MimicManager.CreateMimic(client.Player, template, client.Player.Level);
+                DisplayMessage(client, $"{mimic.Name} has joined your group.");
+            }
+            catch (Exception ex)
+            {
+                DisplayMessage(client, $"Unable to recruit mimic: {ex.Message}");
+            }
+        }
+
+        private static void ShowTemplates(GameClient client)
+        {
+            var templates = MimicManager.GetTemplatesForPlayer(client.Player);
+
+            if (templates.Count == 0)
+            {
+                client.Out.SendMessage("No mimics are currently available.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return;
+            }
+
+            for (int i = 0; i < templates.Count; i++)
+            {
+                MimicTemplate template = templates[i];
+                client.Out.SendMessage($"[{i}] {template.DisplayName} (Level {template.MinimumLevel}-{template.MaximumLevel})", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            }
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mpc.cs
+++ b/GameServer/commands/playercommands/mpc.cs
@@ -1,0 +1,37 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mpc",
+        ePrivLevel.Player,
+        "Toggle mimic prevent combat",
+        "/mpc <true|false>")]
+    public sealed class MimicPreventCombatCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 2 || !bool.TryParse(args[1], out bool value))
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            if (client.Player.TargetObject is MimicNPC mimic)
+            {
+                MimicManager.SetPreventCombat(mimic, value);
+                DisplayMessage(client, $"{mimic.Name} prevent combat set to {value}.");
+            }
+            else
+            {
+                MimicManager.SetPreventCombat(client.Player, value);
+                DisplayMessage(client, $"Set prevent combat for all grouped mimics to {value}.");
+            }
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mpvp.cs
+++ b/GameServer/commands/playercommands/mpvp.cs
@@ -1,0 +1,37 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mpvp",
+        ePrivLevel.Player,
+        "Toggle mimic PvP mode",
+        "/mpvp <true|false>")]
+    public sealed class MimicPvpCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 2 || !bool.TryParse(args[1], out bool value))
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            if (client.Player.TargetObject is MimicNPC mimic)
+            {
+                MimicManager.SetPvPMode(mimic, value);
+                DisplayMessage(client, $"{mimic.Name} PvP mode set to {value}.");
+            }
+            else
+            {
+                MimicManager.SetPvPMode(client.Player, value);
+                DisplayMessage(client, $"Set PvP mode for all grouped mimics to {value}.");
+            }
+        }
+    }
+}

--- a/GameServer/commands/playercommands/mrole.cs
+++ b/GameServer/commands/playercommands/mrole.cs
@@ -1,0 +1,64 @@
+using System;
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&mrole",
+        ePrivLevel.Player,
+        "Assign roles to mimics",
+        "/mrole <leader|puller|tank|cc|assist>")]
+    public sealed class MimicRoleCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            if (args.Length < 2)
+            {
+                DisplaySyntax(client);
+                return;
+            }
+
+            MimicRole role = ParseRole(args[1]);
+            if (role == MimicRole.None)
+            {
+                DisplayMessage(client, "Unknown role.");
+                return;
+            }
+
+            MimicNPC? mimic = GetTargetMimic(client.Player);
+            if (mimic == null)
+            {
+                DisplayMessage(client, "Target a mimic in your group first.");
+                return;
+            }
+
+            MimicManager.AssignRole(mimic, role);
+            DisplayMessage(client, $"{mimic.Name} role set to {role}.");
+        }
+
+        private static MimicNPC? GetTargetMimic(GamePlayer player)
+        {
+            if (player.TargetObject is MimicNPC mimic)
+                return mimic;
+
+            return null;
+        }
+
+        private static MimicRole ParseRole(string value)
+        {
+            return value.ToLowerInvariant() switch
+            {
+                "leader" => MimicRole.Leader,
+                "puller" => MimicRole.Puller,
+                "tank" => MimicRole.Tank,
+                "cc" => MimicRole.CrowdControl,
+                "assist" => MimicRole.Assist,
+                _ => MimicRole.None
+            };
+        }
+    }
+}

--- a/GameServer/commands/playercommands/msummon.cs
+++ b/GameServer/commands/playercommands/msummon.cs
@@ -1,0 +1,21 @@
+using DOL.GS.Mimic;
+using DOL.GS.PacketHandler;
+
+namespace DOL.GS.Commands
+{
+    [CmdAttribute(
+        "&msummon",
+        ePrivLevel.Player,
+        "Summon mimic party members to your location")]
+    public sealed class MimicSummonCommand : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player == null)
+                return;
+
+            MimicManager.SummonGroup(client.Player);
+            DisplayMessage(client, "Mimics summoned to your location.");
+        }
+    }
+}

--- a/GameServer/mimic/MimicCampSettings.cs
+++ b/GameServer/mimic/MimicCampSettings.cs
@@ -1,0 +1,19 @@
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public class MimicCampSettings
+    {
+        public Point3D Location { get; }
+        public int AggroRange { get; }
+        public ConColor MinimumCon { get; }
+        public bool HasFilter => MinimumCon != ConColor.UNKNOWN;
+
+        public MimicCampSettings(Point3D location, int aggroRange, ConColor minimumCon)
+        {
+            Location = location;
+            AggroRange = aggroRange;
+            MinimumCon = minimumCon;
+        }
+    }
+}

--- a/GameServer/mimic/MimicGroupState.cs
+++ b/GameServer/mimic/MimicGroupState.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public class MimicGroupState
+    {
+        private readonly List<MimicNPC> _members = new();
+
+        public GamePlayer Owner { get; }
+        public MimicCampSettings? Camp { get; private set; }
+        public ConColor CampFilter { get; private set; } = ConColor.UNKNOWN;
+        public int CampAggroRange { get; private set; }
+
+        public IReadOnlyList<MimicNPC> Members => _members;
+
+        public MimicGroupState(GamePlayer owner)
+        {
+            Owner = owner;
+            CampAggroRange = owner.CurrentZone?.IsDungeon ?? false ? 250 : 550;
+        }
+
+        public void AddMember(MimicNPC mimic)
+        {
+            if (!_members.Contains(mimic))
+                _members.Add(mimic);
+        }
+
+        public void RemoveMember(MimicNPC mimic)
+        {
+            _members.Remove(mimic);
+        }
+
+        public void SetCamp(MimicCampSettings camp)
+        {
+            Camp = camp;
+            CampAggroRange = camp.AggroRange;
+            CampFilter = camp.MinimumCon;
+        }
+
+        public void ClearCamp()
+        {
+            Camp = null;
+        }
+
+        public void SetAggroRange(int range)
+        {
+            CampAggroRange = range;
+        }
+
+        public void SetFilter(ConColor color)
+        {
+            CampFilter = color;
+        }
+    }
+}

--- a/GameServer/mimic/MimicManager.cs
+++ b/GameServer/mimic/MimicManager.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using DOL.GS.PlayerClass;
+using DOL.GS.Utils;
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public static class MimicManager
+    {
+        private static readonly List<MimicTemplate> _templates = new()
+        {
+            new MimicTemplate("alb_armsman", "Albion Armsman", eRealm.Albion, eCharacterClass.Armsman, 49, 5, 50),
+            new MimicTemplate("alb_cleric", "Albion Cleric", eRealm.Albion, eCharacterClass.Cleric, 183, 5, 50),
+            new MimicTemplate("mid_warrior", "Midgard Warrior", eRealm.Midgard, eCharacterClass.Warrior, 144, 5, 50),
+            new MimicTemplate("mid_healer", "Midgard Healer", eRealm.Midgard, eCharacterClass.Healer, 179, 5, 50),
+            new MimicTemplate("hib_hero", "Hibernia Hero", eRealm.Hibernia, eCharacterClass.Hero, 190, 5, 50),
+            new MimicTemplate("hib_druid", "Hibernia Druid", eRealm.Hibernia, eCharacterClass.Druid, 188, 5, 50)
+        };
+
+        private static readonly ConcurrentDictionary<GamePlayer, MimicGroupState> _groupStates = new();
+        private static readonly ConcurrentDictionary<string, MimicNPC> _activeMimics = new();
+        private static readonly ConcurrentDictionary<string, bool> _activeBattles = new(StringComparer.OrdinalIgnoreCase);
+
+        public static IReadOnlyList<MimicTemplate> GetTemplatesForPlayer(GamePlayer player)
+        {
+            return _templates
+                .Where(t => t.Realm == player.Realm && t.SupportsLevel(player.Level))
+                .OrderBy(t => t.DisplayName)
+                .ToList();
+        }
+
+        public static IReadOnlyList<MimicTemplate> GetTemplatesForRealm(eRealm realm)
+        {
+            return _templates
+                .Where(t => t.Realm == realm)
+                .OrderBy(t => t.DisplayName)
+                .ToList();
+        }
+
+        public static MimicTemplate? FindTemplateByClass(string className)
+        {
+            return _templates.FirstOrDefault(t => string.Equals(t.CharacterClass.ToString(), className, StringComparison.OrdinalIgnoreCase)
+                                                  || string.Equals(t.DisplayName, className, StringComparison.OrdinalIgnoreCase)
+                                                  || string.Equals(t.Id, className, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static MimicNPC? FindMimic(GamePlayer controller, string name)
+        {
+            return GetOrCreateGroupState(controller).Members.FirstOrDefault(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static IReadOnlyList<MimicNPC> GetMimics(GamePlayer player)
+        {
+            return GetOrCreateGroupState(player).Members.ToList();
+        }
+
+        public static MimicNPC CreateMimic(GamePlayer player, MimicTemplate template, int level)
+        {
+            if (player.CurrentRegion == null)
+                throw new InvalidOperationException("Player is not in a valid region.");
+
+            MimicGroupState groupState = GetOrCreateGroupState(player);
+            MimicNPC mimic = new(template, player, groupState, level)
+            {
+                CurrentRegion = player.CurrentRegion,
+                X = player.X + Util.Random(-200, 200),
+                Y = player.Y + Util.Random(-200, 200),
+                Z = player.Z,
+                Heading = player.Heading
+            };
+
+            if (!mimic.AddToWorld())
+                throw new InvalidOperationException("Unable to add mimic to world.");
+
+            EnsureGroupMembership(player, mimic);
+            groupState.AddMember(mimic);
+            _activeMimics[mimic.InternalID] = mimic;
+            return mimic;
+        }
+
+        public static void RemoveMimic(MimicNPC mimic)
+        {
+            if (mimic.Group != null)
+            {
+                mimic.Group.RemoveMember(mimic);
+            }
+
+            mimic.RemoveFromWorld();
+
+            if (_activeMimics.TryRemove(mimic.InternalID, out _))
+            {
+                mimic.GroupState.RemoveMember(mimic);
+            }
+        }
+
+        public static void ClearAllMimics()
+        {
+            foreach (MimicNPC mimic in _activeMimics.Values.ToList())
+            {
+                RemoveMimic(mimic);
+            }
+        }
+
+        public static void SummonGroup(GamePlayer player)
+        {
+            foreach (MimicNPC mimic in GetMimics(player))
+            {
+                mimic.TeleportTo(player);
+            }
+        }
+
+        public static void SetPreventCombat(GamePlayer player, bool value)
+        {
+            foreach (MimicNPC mimic in GetMimics(player))
+            {
+                mimic.SetPreventCombat(value);
+            }
+        }
+
+        public static void SetPreventCombat(MimicNPC mimic, bool value)
+        {
+            mimic.SetPreventCombat(value);
+        }
+
+        public static void SetPvPMode(GamePlayer player, bool value)
+        {
+            foreach (MimicNPC mimic in GetMimics(player))
+            {
+                mimic.SetPvPMode(value);
+            }
+        }
+
+        public static void SetPvPMode(MimicNPC mimic, bool value)
+        {
+            mimic.SetPvPMode(value);
+        }
+
+        public static void AssignRole(MimicNPC mimic, MimicRole role)
+        {
+            mimic.AssignRole(role);
+        }
+
+        public static void GuardTarget(MimicNPC mimic, GameLiving? target)
+        {
+            mimic.SetGuardTarget(target);
+        }
+
+        public static void SetCamp(GamePlayer player, Point3D location, int aggroRange, ConColor filter)
+        {
+            MimicGroupState state = GetOrCreateGroupState(player);
+            state.SetCamp(new MimicCampSettings(location, aggroRange, filter));
+        }
+
+        public static void ClearCamp(GamePlayer player)
+        {
+            GetOrCreateGroupState(player).ClearCamp();
+        }
+
+        public static void SetAggroRange(GamePlayer player, int range)
+        {
+            GetOrCreateGroupState(player).SetAggroRange(range);
+        }
+
+        public static void SetFilter(GamePlayer player, ConColor color)
+        {
+            GetOrCreateGroupState(player).SetFilter(color);
+        }
+
+        public static MimicGroupState GetOrCreateGroupState(GamePlayer player)
+        {
+            return _groupStates.GetOrAdd(player, p => new MimicGroupState(p));
+        }
+
+        public static bool TryParseConColor(string text, out ConColor color)
+        {
+            color = text.ToLowerInvariant() switch
+            {
+                "grey" => ConColor.GREY,
+                "gray" => ConColor.GREY,
+                "green" => ConColor.GREEN,
+                "blue" => ConColor.BLUE,
+                "yellow" => ConColor.YELLOW,
+                "orange" => ConColor.ORANGE,
+                "red" => ConColor.RED,
+                "purple" => ConColor.PURPLE,
+                _ => ConColor.UNKNOWN
+            };
+
+            return color != ConColor.UNKNOWN;
+        }
+
+        public static void SetBattleState(string regionKey, bool active)
+        {
+            if (active)
+                _activeBattles[regionKey] = true;
+            else
+                _activeBattles.TryRemove(regionKey, out _);
+        }
+
+        public static bool IsBattleActive(string regionKey)
+        {
+            return _activeBattles.ContainsKey(regionKey);
+        }
+
+        private static void EnsureGroupMembership(GamePlayer player, MimicNPC mimic)
+        {
+            Group? group = player.Group;
+            if (group == null)
+            {
+                group = new Group(player);
+                GroupMgr.AddGroup(group);
+                group.AddMember(player);
+            }
+
+            if (group.GetMembersInTheGroup().Contains(mimic))
+                return;
+
+            group.AddMember(mimic);
+        }
+    }
+}

--- a/GameServer/mimic/MimicNPC.cs
+++ b/GameServer/mimic/MimicNPC.cs
@@ -1,0 +1,87 @@
+using System;
+using DOL.AI.Brain;
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public class MimicNPC : GameNPC
+    {
+        private readonly MimicTemplate _template;
+        private readonly MimicBrain _brain;
+
+        public MimicRole Role { get; private set; }
+        public bool PreventCombat { get; private set; }
+        public bool PvPMode { get; private set; }
+        public GameLiving? GuardTarget { get; private set; }
+        public MimicGroupState GroupState { get; }
+        public GamePlayer Owner { get; }
+        public MimicTemplate Template => _template;
+
+        public MimicNPC(MimicTemplate template, GamePlayer owner, MimicGroupState groupState, int level)
+        {
+            _template = template;
+            Owner = owner;
+            GroupState = groupState;
+            Name = template.DisplayName;
+            Level = (byte)Math.Clamp(level, template.MinimumLevel, template.MaximumLevel);
+            Realm = template.Realm;
+            Model = template.ModelId;
+            Flags |= eFlags.PEACE;
+            Role = MimicRole.None;
+            PreventCombat = false;
+            PvPMode = false;
+            _brain = new MimicBrain(owner, this);
+            SetOwnBrain(_brain);
+        }
+
+        public void AssignRole(MimicRole role)
+        {
+            Role = role;
+        }
+
+        public void SetPreventCombat(bool value)
+        {
+            PreventCombat = value;
+            _brain.SetPreventCombat(value);
+        }
+
+        public void SetPvPMode(bool value)
+        {
+            PvPMode = value;
+            _brain.SetPvPMode(value);
+        }
+
+        public void SetGuardTarget(GameLiving? living)
+        {
+            GuardTarget = living;
+            _brain.SetGuardTarget(living);
+        }
+
+        public void TeleportTo(GamePlayer player)
+        {
+            if (player.CurrentRegion == null)
+                return;
+
+            MoveTo(player.CurrentRegionID, player.X, player.Y, player.Z, player.Heading);
+        }
+
+        public override bool AddToWorld()
+        {
+            bool result = base.AddToWorld();
+            if (result)
+            {
+                Follow(Owner);
+            }
+
+            return result;
+        }
+
+        public void Follow(GameLiving target)
+        {
+            if (target == null)
+                return;
+
+            Follow(target, 150, 350);
+        }
+    }
+}

--- a/GameServer/mimic/MimicRole.cs
+++ b/GameServer/mimic/MimicRole.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace DOL.GS.Mimic
+{
+    [Flags]
+    public enum MimicRole
+    {
+        None = 0,
+        Leader = 1 << 0,
+        Puller = 1 << 1,
+        Tank = 1 << 2,
+        CrowdControl = 1 << 3,
+        Assist = 1 << 4
+    }
+}

--- a/GameServer/mimic/MimicTemplate.cs
+++ b/GameServer/mimic/MimicTemplate.cs
@@ -1,0 +1,32 @@
+using DOL.GS.PlayerClass;
+using DOL.GS;
+
+namespace DOL.GS.Mimic
+{
+    public sealed class MimicTemplate
+    {
+        public string Id { get; }
+        public string DisplayName { get; }
+        public eRealm Realm { get; }
+        public eCharacterClass CharacterClass { get; }
+        public ushort ModelId { get; }
+        public byte MinimumLevel { get; }
+        public byte MaximumLevel { get; }
+
+        public MimicTemplate(string id, string displayName, eRealm realm, eCharacterClass characterClass, ushort modelId, byte minLevel, byte maxLevel)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Realm = realm;
+            CharacterClass = characterClass;
+            ModelId = modelId;
+            MinimumLevel = minLevel;
+            MaximumLevel = maxLevel;
+        }
+
+        public bool SupportsLevel(int level)
+        {
+            return level >= MinimumLevel && level <= MaximumLevel;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ The easiest way to get started with OpenDAoC is to use Docker. Check out the `do
 
 For detailed instructions and additional setup options, refer to the full [OpenDAoC Documentation](https://www.opendaoc.com/docs/).
 
+## Installing the .NET SDK locally
+
+Some workflows—such as running tests with `dotnet test`—require the .NET CLI to be available on your machine. The repository includes a helper script that downloads the required SDK without needing global installation rights. Run the following from the repository root:
+
+```bash
+./scripts/install-dotnet.sh
+```
+
+By default the script installs the latest .NET 9 SDK into `.dotnet/` inside the repository. To target a specific version, pass it as the first argument, for example:
+
+```bash
+./scripts/install-dotnet.sh 9.0.100
+```
+
+After the installation completes, add the SDK to your shell `PATH`:
+
+```bash
+export DOTNET_ROOT="$(pwd)/.dotnet"
+export PATH="$DOTNET_ROOT:$PATH"
+```
+
+You can confirm that the CLI is available with `dotnet --info`.
+
 ## Releases
 
 Releases for OpenDAoC are available at [OpenDAoC Releases](https://github.com/OpenDAoC/OpenDAoC-Core/releases).

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOTNET_DIR="${DOTNET_INSTALL_DIR:-${REPO_ROOT}/.dotnet}"
+DEFAULT_CHANNEL="9.0"
+
+if [[ -n "${1:-}" ]]; then
+    VERSION_ARG=("--version" "$1")
+    echo "Installing .NET SDK version $1 into ${DOTNET_DIR}" >&2
+else
+    VERSION_ARG=("--channel" "${DEFAULT_CHANNEL}")
+    echo "Installing latest .NET SDK from channel ${DEFAULT_CHANNEL} into ${DOTNET_DIR}" >&2
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+install_script="${tmp_dir}/dotnet-install.sh"
+
+curl -sSL https://dot.net/v1/dotnet-install.sh -o "${install_script}"
+chmod +x "${install_script}"
+
+"${install_script}" "${VERSION_ARG[@]}" --install-dir "${DOTNET_DIR}" --no-path
+
+echo "Installation complete." >&2
+echo
+cat <<EOM
+To start using the .NET SDK, add the following to your shell session:
+
+  export DOTNET_ROOT="${DOTNET_DIR}"
+  export PATH="\$DOTNET_ROOT:\$PATH"
+
+Then verify with:
+
+  dotnet --info
+EOM


### PR DESCRIPTION
## Summary
- add a server-side MimicManager with templates, group state tracking, and battle toggles for mimic bots
- introduce MimicNPC and MimicBrain to create controllable party-following mimics with guard, PvP, and combat flags
- implement player-facing /m* commands for recruiting, configuring, summoning, and managing mimic parties and battleground spawns

## Testing
- `dotnet build DOLLinux.sln -v minimal`
- `dotnet test DOLLinux.sln -v minimal` *(fails: test host crashes when GameServer startup asserts database connectivity in existing integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68d05f627d30832f81e94126770e6453