### PR TITLE
Handle unsupported database types during server init

### DIFF
--- a/GameServer/GameServer.cs
+++ b/GameServer/GameServer.cs
@@ -1163,12 +1163,20 @@ namespace DOL.GS
 		/// <returns>True if the database was successfully initialized</returns>
 		public bool InitDB()
 		{
-			if (m_database == null)
-			{
-				m_database = ObjectDatabase.GetObjectDatabase(Configuration.DBType, Configuration.DBConnectionString);
+                        if (m_database == null)
+                        {
+                                m_database = ObjectDatabase.GetObjectDatabase(Configuration.DBType, Configuration.DBConnectionString);
 
-				try
-				{
+                                if (m_database == null)
+                                {
+                                        if (log.IsFatalEnabled)
+                                                log.FatalFormat("Unsupported database type '{0}'. Check your server configuration (config/serverconfig.xml).", Configuration.DBType);
+
+                                        return false;
+                                }
+
+                                try
+                                {
 					//We will search our assemblies for DataTables by reflection so
 					//it is not neccessary anymore to register new tables with the
 					//server, it is done automatically!


### PR DESCRIPTION
## Summary
- stop the game server from crashing with a NullReferenceException when the configured database type is unsupported
- log a fatal message that directs administrators to fix config/serverconfig.xml and abort initialization gracefully

## Testing
- ⚠️ `dotnet build DOLLinux.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d1d08ed988832fa4ec9e0a79fd785a