### PR TITLE
Ensure SQLite default DB type when server config omits DBType

### DIFF
--- a/GameServer/GameServerConfiguration.cs
+++ b/GameServer/GameServerConfiguration.cs
@@ -186,29 +186,43 @@ namespace DOL.GS
             m_gmActionsLoggerName = root["Server"]["GMActionLoggerName"].GetString(m_gmActionsLoggerName);
             m_invalidNamesFile = root["Server"]["InvalidNamesFile"].GetString(m_invalidNamesFile);
 
-            string db = root["Server"]["DBType"].GetString("XML");
-            switch (db.ToLower())
+            string db = root["Server"]["DBType"].GetString(string.Empty);
+
+            if (string.IsNullOrWhiteSpace(db))
+            {
+                db = "sqlite";
+            }
+
+            db = db.Trim().ToLowerInvariant();
+
+            switch (db)
             {
                 case "xml":
+                case "database_xml":
                     m_dbType = EConnectionType.DATABASE_XML;
                     break;
                 case "mysql":
+                case "database_mysql":
                     m_dbType = EConnectionType.DATABASE_MYSQL;
                     break;
                 case "sqlite":
+                case "database_sqlite":
                     m_dbType = EConnectionType.DATABASE_SQLITE;
                     break;
                 case "mssql":
+                case "database_mssql":
                     m_dbType = EConnectionType.DATABASE_MSSQL;
                     break;
                 case "odbc":
+                case "database_odbc":
                     m_dbType = EConnectionType.DATABASE_ODBC;
                     break;
                 case "oledb":
+                case "database_oledb":
                     m_dbType = EConnectionType.DATABASE_OLEDB;
                     break;
                 default:
-                    m_dbType = EConnectionType.DATABASE_XML;
+                    m_dbType = EConnectionType.DATABASE_SQLITE;
                     break;
             }
 

--- a/Tests/UnitTests/UT_GameServerConfiguration.cs
+++ b/Tests/UnitTests/UT_GameServerConfiguration.cs
@@ -1,0 +1,77 @@
+/*
+ * DAWN OF LIGHT - The first free open source DAoC server emulator
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+using System;
+using System.IO;
+using DOL.Database.Connection;
+using DOL.GS;
+using NUnit.Framework;
+
+namespace DOL.Tests.Unit.Gameserver
+{
+    [TestFixture]
+    public class UT_GameServerConfiguration
+    {
+        private static string WriteConfigToTempFile(string xmlContent)
+        {
+            var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
+            File.WriteAllText(tempFile, xmlContent);
+            return tempFile;
+        }
+
+        [Test]
+        public void LoadFromXml_WithEmptyDbType_DefaultsToSqlite()
+        {
+            const string xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><root><Server><DBType></DBType></Server></root>";
+            var filePath = WriteConfigToTempFile(xml);
+
+            try
+            {
+                var config = new GameServerConfiguration();
+                config.LoadFromXMLFile(new FileInfo(filePath));
+
+                Assert.That(config.DBType, Is.EqualTo(EConnectionType.DATABASE_SQLITE));
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Test]
+        [TestCase("DATABASE_SQLITE")]
+        [TestCase(" sqlite ")]
+        public void LoadFromXml_WithDatabasePrefixedEnum_ParsesAsSqlite(string input)
+        {
+            string xml = $"<?xml version=\"1.0\" encoding=\"utf-8\"?><root><Server><DBType>{input}</DBType></Server></root>";
+            var filePath = WriteConfigToTempFile(xml);
+
+            try
+            {
+                var config = new GameServerConfiguration();
+                config.LoadFromXMLFile(new FileInfo(filePath));
+
+                Assert.That(config.DBType, Is.EqualTo(EConnectionType.DATABASE_SQLITE));
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- default the database type to SQLite when the server configuration omits or leaves the DBType empty
- accept enum-style DBType values such as `DATABASE_SQLITE` while still mapping them to SQLite
- add unit tests covering DBType parsing edge cases for empty and enum-formatted values

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68d1d3c46aa0832f9e457f55b8751197