### PR TITLE
Use invariant culture for database number formatting

### DIFF
--- a/CoreDatabase/ObjectDatabase.cs
+++ b/CoreDatabase/ObjectDatabase.cs
@@ -24,7 +24,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Number Format Info to Use for Database
 		/// </summary>
-		protected static readonly NumberFormatInfo Nfi = new CultureInfo("en-US", false).NumberFormat;
+                protected static readonly NumberFormatInfo Nfi = CultureInfo.InvariantCulture.NumberFormat;
 
 		private static readonly ConcurrentDictionary<Type, Func<IEnumerable<object>, Array>> _castToArrayCache = new();
 


### PR DESCRIPTION
## Summary
- replace the en-US culture dependency in `ObjectDatabase` with the invariant culture number format
- ensure the database layer initializes correctly in globalization-invariant environments

## Testing
- `dotnet build DOLLinux.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68d1d8289230832f8bb049286b06e416