### PR TITLE
Use invariant culture for server property formatting

### DIFF
--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -2584,12 +2584,11 @@ namespace DOL.GS.ServerProperties
 								serverProp.Category = att.Category;
 								serverProp.Key = att.Key;
 								serverProp.Description = att.Description;
-								if (att.DefaultValue is double)
-								{
-									CultureInfo myCIintl = new CultureInfo("en-US", false);
-									IFormatProvider provider = myCIintl.NumberFormat;
-									serverProp.DefaultValue = ((double)att.DefaultValue).ToString(provider);
-								}
+                                                                if (att.DefaultValue is double)
+                                                                {
+                                                                        IFormatProvider provider = CultureInfo.InvariantCulture.NumberFormat;
+                                                                        serverProp.DefaultValue = ((double)att.DefaultValue).ToString(provider);
+                                                                }
 								else
 								{
 									serverProp.DefaultValue = att.DefaultValue.ToString();
@@ -2635,8 +2634,7 @@ namespace DOL.GS.ServerProperties
 					log.WarnFormat("Property {0} is ReadOnly, Value won't be changed - {1} !", key, field.GetValue(null));
 				
 				//we do this because we need "1.0" to be considered double sometimes its "1,0" in other countries
-				CultureInfo myCIintl = new CultureInfo("en-US", false);
-				IFormatProvider provider = myCIintl.NumberFormat;
+                                IFormatProvider provider = CultureInfo.InvariantCulture.NumberFormat;
 				field.SetValue(null, Convert.ChangeType(prop.Value, attrib.DefaultValue.GetType(), provider));
 			}
 			catch (Exception e)


### PR DESCRIPTION
## Summary
- replace hardcoded en-US CultureInfo usage with CultureInfo.InvariantCulture when formatting server property values
- ensure server property loading and defaults work in globalization-invariant environments

## Testing
- dotnet build GameServer/GameServer.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68d1db9b9d8c832f876b58d33ca94bb0