### PR TITLE
Fix NPC lookup casting and guard initialization

### DIFF
--- a/GameServer/events/keep/RelicGuardsOnKeepTaken.cs
+++ b/GameServer/events/keep/RelicGuardsOnKeepTaken.cs
@@ -90,16 +90,21 @@ namespace DOL.GS.GameEvents
                     TranslationId = translationId
                 };
 
-                foreach (IArea area in guard.CurrentAreas)
-                {
-                    if (area is not KeepArea keepArea)
-                        continue;
+                Zone zone = guard.CurrentRegion?.GetZone(guard.X, guard.Y);
 
-                    guard.Component = new()
+                if (zone != null)
+                {
+                    foreach (IArea area in zone.GetAreasOfSpot(guard.X, guard.Y, guard.Z))
                     {
-                        Keep = keepArea.Keep
-                    };
-                    break;
+                        if (area is not KeepArea keepArea)
+                            continue;
+
+                        guard.Component = new()
+                        {
+                            Keep = keepArea.Keep
+                        };
+                        break;
+                    }
                 }
 
                 GuardTemplateMgr.RefreshTemplate(guard);

--- a/GameServer/gameutils/ZoneBonusRotator.cs
+++ b/GameServer/gameutils/ZoneBonusRotator.cs
@@ -651,45 +651,38 @@ namespace DOL.GS.Scripts
         private static void ClearPvEZones()
         {
             // Clear PvE Zones
-            albDBZone = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentAlbionZone));
-            albDBZoneSI = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentAlbionZoneSI));
-            midDBZone = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentMidgardZone));
-            midDBZoneSI = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentMidgardZoneSI));
-            hibDBZone = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentHiberniaZone));
-            hibDBZoneSI = DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(currentHiberniaZoneSI));
+            albDBZone = GetZoneById(currentAlbionZone);
+            albDBZoneSI = GetZoneById(currentAlbionZoneSI);
+            midDBZone = GetZoneById(currentMidgardZone);
+            midDBZoneSI = GetZoneById(currentMidgardZoneSI);
+            hibDBZone = GetZoneById(currentHiberniaZone);
+            hibDBZoneSI = GetZoneById(currentHiberniaZoneSI);
 
-            albDBZone.Experience = 0;
-            albDBZoneSI.Experience = 0;
-            midDBZone.Experience = 0;
-            midDBZoneSI.Experience = 0;
-            hibDBZone.Experience = 0;
-            hibDBZoneSI.Experience = 0;
+            ResetZoneExperience(albDBZone);
+            ResetZoneExperience(albDBZoneSI);
+            ResetZoneExperience(midDBZone);
+            ResetZoneExperience(midDBZoneSI);
+            ResetZoneExperience(hibDBZone);
+            ResetZoneExperience(hibDBZoneSI);
 
-            GameServer.Database.SaveObject(albDBZone);
-            GameServer.Database.SaveObject(albDBZoneSI);
-            GameServer.Database.SaveObject(midDBZone);
-            GameServer.Database.SaveObject(midDBZoneSI);
-            GameServer.Database.SaveObject(hibDBZone);
-            GameServer.Database.SaveObject(midDBZoneSI);
 
-            
             foreach (var zone in albionClassicZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             foreach (var zone in albionSIZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             foreach (var zone in midgardClassicZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             foreach (var zone in midgardSIZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             foreach (var zone in hiberniaClassicZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             foreach (var zone in hiberniaSIZones)
-                WorldMgr.Zones[(ushort)zone].BonusExperience = 0;
+                ResetWorldZoneBonus(zone);
 
             /*
             WorldMgr.Zones[(ushort)albionClassicZones[currentAlbionZone]].BonusExperience = 0;
@@ -699,6 +692,32 @@ namespace DOL.GS.Scripts
             WorldMgr.Zones[(ushort)hiberniaClassicZones[currentHiberniaZone]].BonusExperience = 0;
             WorldMgr.Zones[(ushort)hiberniaSIZones[currentHiberniaZoneSI]].BonusExperience = 0;
             */
+
+            static DbZone GetZoneById(int zoneId)
+            {
+                if (zoneId <= 0)
+                    return null;
+
+                return DOLDB<DbZone>.SelectObject(DB.Column("ZoneID").IsEqualTo(zoneId));
+            }
+
+            static void ResetZoneExperience(DbZone zone)
+            {
+                if (zone == null)
+                    return;
+
+                zone.Experience = 0;
+                GameServer.Database.SaveObject(zone);
+            }
+
+            static void ResetWorldZoneBonus(int zoneId)
+            {
+                if (zoneId <= 0)
+                    return;
+
+                if (WorldMgr.Zones.TryGetValue((ushort)zoneId, out Zone worldZone))
+                    worldZone.BonusExperience = 0;
+            }
         }
     }
 }

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -702,43 +702,30 @@ namespace DOL.GS
 			return null;
 		}
 
-		public static object[] OfTypeAndToArray<T>(this IEnumerable<T> input, Type type)
-		{
-			MethodInfo methodOfType = typeof(Enumerable).GetMethod("OfType");
-			MethodInfo genericOfType = methodOfType.MakeGenericMethod(new Type[]{ type });
-			// Use .NET 4 covariance
-			var result = (IEnumerable<object>) genericOfType.Invoke(null, new object[] { input });
-			
-			MethodInfo methodToArray = typeof(Enumerable).GetMethod("ToArray");
-			MethodInfo genericToArray = methodToArray.MakeGenericMethod(new Type[]{ type });
-			
-			return (object[]) genericToArray.Invoke(null, new object[] { result });
-		}
+                /// <summary>
+                /// Searches for all objects from a specific region
+                /// </summary>
+                /// <param name="regionID">The region to search</param>
+                /// <param name="objectType">The type of the object you search</param>
+                /// <returns>All objects with the specified parameters</returns>
+                public static GameObject[] GetobjectsFromRegion(ushort regionID, Type objectType)
+                {
+                        Region reg;
+                        if (!m_regions.TryGetValue(regionID, out reg))
+                                return new GameObject[0];
 
-		/// <summary>
-		/// Searches for all objects from a specific region
-		/// </summary>
-		/// <param name="regionID">The region to search</param>
-		/// <param name="objectType">The type of the object you search</param>
-		/// <returns>All objects with the specified parameters</returns>
-		public static GameObject[] GetobjectsFromRegion(ushort regionID, Type objectType)
-		{
-			Region reg;
-			if (!m_regions.TryGetValue(regionID, out reg))
-				return new GameObject[0];
-
-			return (GameObject[]) reg.Objects.Where(obj => obj != null).OfTypeAndToArray(objectType);
-		}
+                        return reg.Objects.Where(obj => obj != null && objectType.IsInstanceOfType(obj)).ToArray();
+                }
 		
 		/// <summary>
 		/// Searches for all GameStaticItem from a specific region
 		/// </summary>
 		/// <param name="regionID">The region to search</param>
 		/// <returns>All NPCs with the specified parameters</returns>
-		public static GameStaticItem[] GetStaticItemFromRegion(ushort regionID)
-		{
-			return (GameStaticItem[])GetobjectsFromRegion(regionID, typeof(GameStaticItem));
-		}
+                public static GameStaticItem[] GetStaticItemFromRegion(ushort regionID)
+                {
+                        return GetobjectsFromRegion(regionID, typeof(GameStaticItem)).Cast<GameStaticItem>().ToArray();
+                }
 
 		/// <summary>
 		/// Searches for all objects with the given name, from a specific region and realm
@@ -754,8 +741,10 @@ namespace DOL.GS
 			if (!m_regions.TryGetValue(regionID, out reg))
 				return new GameObject[0];
 			
-			return (GameObject[]) reg.Objects.Where(obj => obj != null && obj.Realm == realm && obj.Name == name).OfTypeAndToArray(objectType);
-		}
+                        return reg.Objects
+                                .Where(obj => obj != null && obj.Realm == realm && obj.Name == name && objectType.IsInstanceOfType(obj))
+                                .ToArray();
+                }
 
 		/// <summary>
 		/// Returns the npcs in a given region
@@ -777,11 +766,12 @@ namespace DOL.GS
 		/// <param name="realm">The realm of the object we search!</param>
 		/// <param name="objectType">The type of the object you search</param>
 		/// <returns>All objects with the specified parameters</returns>b
-		public static GameObject[] GetObjectsByName(string name, eRealm realm, Type objectType)
-		{
-			return (GameObject[]) m_regions.Values.Select(reg => GetObjectsByNameFromRegion(name, reg.ID, realm, objectType))
-				.SelectMany(objs => objs).OfTypeAndToArray(objectType);
-		}
+                public static GameObject[] GetObjectsByName(string name, eRealm realm, Type objectType)
+                {
+                        return m_regions.Values
+                                .SelectMany(reg => GetObjectsByNameFromRegion(name, reg.ID, realm, objectType))
+                                .ToArray();
+                }
 
 		/// <summary>
 		/// Searches for all NPCs with the given name, from a specific region and realm
@@ -790,10 +780,10 @@ namespace DOL.GS
 		/// <param name="regionID">The region to search</param>
 		/// <param name="realm">The realm of the object we search!</param>
 		/// <returns>All NPCs with the specified parameters</returns>
-		public static GameNPC[] GetNPCsByNameFromRegion(string name, ushort regionID, eRealm realm)
-		{
-			return (GameNPC[])GetObjectsByNameFromRegion(name, regionID, realm, typeof(GameNPC));
-		}
+                public static GameNPC[] GetNPCsByNameFromRegion(string name, ushort regionID, eRealm realm)
+                {
+                        return GetObjectsByNameFromRegion(name, regionID, realm, typeof(GameNPC)).Cast<GameNPC>().ToArray();
+                }
 
 		/// <summary>
 		/// Searches for all NPCs with the given name and realm in ALL regions!
@@ -801,10 +791,10 @@ namespace DOL.GS
 		/// <param name="name">The name of the object to search</param>
 		/// <param name="realm">The realm of the object we search!</param>
 		/// <returns>All NPCs with the specified parameters</returns>b
-		public static GameNPC[] GetNPCsByName(string name, eRealm realm)
-		{
-			return (GameNPC[])GetObjectsByName(name, realm, typeof(GameNPC));
-		}
+                public static GameNPC[] GetNPCsByName(string name, eRealm realm)
+                {
+                        return GetObjectsByName(name, realm, typeof(GameNPC)).Cast<GameNPC>().ToArray();
+                }
 
 		/// <summary>
 		/// Searches for all NPCs with the given guild and realm in ALL regions!


### PR DESCRIPTION
## Summary
- update world object queries to filter by type without invalid array casts
- set relic guard keep assignments using zone lookups to avoid null references
- guard PvE zone reset logic against missing database zones and duplicate saves

## Testing
- dotnet build DOLLinux.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d1e097b06c832fa03ca6dd7f95fae6