### PR TITLE
Enhance mimic role logic and expand class roster

### DIFF
--- a/GameServer/commands/playercommands/mlfg.cs
+++ b/GameServer/commands/playercommands/mlfg.cs
@@ -62,7 +62,8 @@ namespace DOL.GS.Commands
             for (int i = 0; i < templates.Count; i++)
             {
                 MimicTemplate template = templates[i];
-                client.Out.SendMessage($"[{i}] {template.DisplayName} (Level {template.MinimumLevel}-{template.MaximumLevel})", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                string roleText = MimicRoleInfo.ToDisplayString(template.DefaultRole);
+                client.Out.SendMessage($"[{i}] {template.DisplayName} (Level {template.MinimumLevel}-{template.MaximumLevel}) - Role: {roleText}", eChatType.CT_System, eChatLoc.CL_SystemWindow);
             }
         }
     }

--- a/GameServer/commands/playercommands/mrole.cs
+++ b/GameServer/commands/playercommands/mrole.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DOL.GS.Mimic;
 using DOL.GS.PacketHandler;
 
@@ -8,7 +9,7 @@ namespace DOL.GS.Commands
         "&mrole",
         ePrivLevel.Player,
         "Assign roles to mimics",
-        "/mrole <leader|puller|tank|cc|assist>")]
+        "/mrole <role[,role...]>")]
     public sealed class MimicRoleCommand : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
@@ -19,13 +20,14 @@ namespace DOL.GS.Commands
             if (args.Length < 2)
             {
                 DisplaySyntax(client);
+                DisplayMessage(client, $"Available roles: {MimicRoleInfo.GetSyntax()}.");
                 return;
             }
 
-            MimicRole role = ParseRole(args[1]);
-            if (role == MimicRole.None)
+            string requested = string.Join(' ', args.Skip(1));
+            if (!MimicRoleInfo.TryParse(requested, out MimicRole role))
             {
-                DisplayMessage(client, "Unknown role.");
+                DisplayMessage(client, $"Unknown role. Available roles: {MimicRoleInfo.GetSyntax()}.");
                 return;
             }
 
@@ -37,7 +39,7 @@ namespace DOL.GS.Commands
             }
 
             MimicManager.AssignRole(mimic, role);
-            DisplayMessage(client, $"{mimic.Name} role set to {role}.");
+            DisplayMessage(client, $"{mimic.Name} role updated to {MimicRoleInfo.ToDisplayString(role)}.");
         }
 
         private static MimicNPC? GetTargetMimic(GamePlayer player)
@@ -48,17 +50,5 @@ namespace DOL.GS.Commands
             return null;
         }
 
-        private static MimicRole ParseRole(string value)
-        {
-            return value.ToLowerInvariant() switch
-            {
-                "leader" => MimicRole.Leader,
-                "puller" => MimicRole.Puller,
-                "tank" => MimicRole.Tank,
-                "cc" => MimicRole.CrowdControl,
-                "assist" => MimicRole.Assist,
-                _ => MimicRole.None
-            };
-        }
     }
 }

--- a/GameServer/mimic/MimicGroupState.cs
+++ b/GameServer/mimic/MimicGroupState.cs
@@ -52,5 +52,16 @@ namespace DOL.GS.Mimic
         {
             CampFilter = color;
         }
+
+        public MimicNPC? GetLeader()
+        {
+            foreach (MimicNPC member in _members)
+            {
+                if (member.Role.HasFlag(MimicRole.Leader) && member.IsAlive)
+                    return member;
+            }
+
+            return null;
+        }
     }
 }

--- a/GameServer/mimic/MimicManager.cs
+++ b/GameServer/mimic/MimicManager.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using DOL.GS;
 using DOL.GS.PacketHandler;
-using DOL.GS.PlayerClass;
 using DOL.GS.Utils;
 
 namespace DOL.GS.Mimic
@@ -13,13 +12,80 @@ namespace DOL.GS.Mimic
     {
         private static readonly List<MimicTemplate> _templates = new()
         {
-            new MimicTemplate("alb_armsman", "Albion Armsman", eRealm.Albion, eCharacterClass.Armsman, 49, 5, 50),
-            new MimicTemplate("alb_cleric", "Albion Cleric", eRealm.Albion, eCharacterClass.Cleric, 183, 5, 50),
-            new MimicTemplate("mid_warrior", "Midgard Warrior", eRealm.Midgard, eCharacterClass.Warrior, 144, 5, 50),
-            new MimicTemplate("mid_healer", "Midgard Healer", eRealm.Midgard, eCharacterClass.Healer, 179, 5, 50),
-            new MimicTemplate("hib_hero", "Hibernia Hero", eRealm.Hibernia, eCharacterClass.Hero, 190, 5, 50),
-            new MimicTemplate("hib_druid", "Hibernia Druid", eRealm.Hibernia, eCharacterClass.Druid, 188, 5, 50)
+            // Albion
+            CreateTemplate("alb_armsman", "Albion Armsman", eRealm.Albion, eCharacterClass.Armsman, MimicRole.Tank | MimicRole.DamageDealer),
+            CreateTemplate("alb_paladin", "Albion Paladin", eRealm.Albion, eCharacterClass.Paladin, MimicRole.Tank | MimicRole.Support),
+            CreateTemplate("alb_scout", "Albion Scout", eRealm.Albion, eCharacterClass.Scout, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("alb_infiltrator", "Albion Infiltrator", eRealm.Albion, eCharacterClass.Infiltrator, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("alb_mercenary", "Albion Mercenary", eRealm.Albion, eCharacterClass.Mercenary, MimicRole.DamageDealer | MimicRole.Assist),
+            CreateTemplate("alb_reaver", "Albion Reaver", eRealm.Albion, eCharacterClass.Reaver, MimicRole.Tank | MimicRole.DamageDealer),
+            CreateTemplate("alb_friar", "Albion Friar", eRealm.Albion, eCharacterClass.Friar, MimicRole.Healer | MimicRole.Support | MimicRole.DamageDealer),
+            CreateTemplate("alb_cleric", "Albion Cleric", eRealm.Albion, eCharacterClass.Cleric, MimicRole.Healer | MimicRole.Support),
+            CreateTemplate("alb_heretic", "Albion Heretic", eRealm.Albion, eCharacterClass.Heretic, MimicRole.Support | MimicRole.DamageDealer),
+            CreateTemplate("alb_minstrel", "Albion Minstrel", eRealm.Albion, eCharacterClass.Minstrel, MimicRole.Support | MimicRole.CrowdControl | MimicRole.Scout | MimicRole.DamageDealer),
+            CreateTemplate("alb_sorcerer", "Albion Sorcerer", eRealm.Albion, eCharacterClass.Sorcerer, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("alb_wizard", "Albion Wizard", eRealm.Albion, eCharacterClass.Wizard, MimicRole.DamageDealer),
+            CreateTemplate("alb_cabalist", "Albion Cabalist", eRealm.Albion, eCharacterClass.Cabalist, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("alb_theurgist", "Albion Theurgist", eRealm.Albion, eCharacterClass.Theurgist, MimicRole.CrowdControl | MimicRole.Support),
+            CreateTemplate("alb_necromancer", "Albion Necromancer", eRealm.Albion, eCharacterClass.Necromancer, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("alb_mauler", "Albion Mauler", eRealm.Albion, eCharacterClass.MaulerAlb, MimicRole.Tank | MimicRole.Support),
+
+            // Midgard
+            CreateTemplate("mid_warrior", "Midgard Warrior", eRealm.Midgard, eCharacterClass.Warrior, MimicRole.Tank | MimicRole.DamageDealer),
+            CreateTemplate("mid_berserker", "Midgard Berserker", eRealm.Midgard, eCharacterClass.Berserker, MimicRole.DamageDealer),
+            CreateTemplate("mid_savage", "Midgard Savage", eRealm.Midgard, eCharacterClass.Savage, MimicRole.DamageDealer),
+            CreateTemplate("mid_thane", "Midgard Thane", eRealm.Midgard, eCharacterClass.Thane, MimicRole.Tank | MimicRole.Support),
+            CreateTemplate("mid_valkyrie", "Midgard Valkyrie", eRealm.Midgard, eCharacterClass.Valkyrie, MimicRole.Tank | MimicRole.Healer | MimicRole.Support),
+            CreateTemplate("mid_skald", "Midgard Skald", eRealm.Midgard, eCharacterClass.Skald, MimicRole.Support | MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("mid_hunter", "Midgard Hunter", eRealm.Midgard, eCharacterClass.Hunter, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("mid_shadowblade", "Midgard Shadowblade", eRealm.Midgard, eCharacterClass.Shadowblade, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("mid_spiritmaster", "Midgard Spiritmaster", eRealm.Midgard, eCharacterClass.Spiritmaster, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("mid_runemaster", "Midgard Runemaster", eRealm.Midgard, eCharacterClass.Runemaster, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("mid_bonedancer", "Midgard Bonedancer", eRealm.Midgard, eCharacterClass.Bonedancer, MimicRole.DamageDealer | MimicRole.Support),
+            CreateTemplate("mid_warlock", "Midgard Warlock", eRealm.Midgard, eCharacterClass.Warlock, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("mid_shaman", "Midgard Shaman", eRealm.Midgard, eCharacterClass.Shaman, MimicRole.Healer | MimicRole.Support),
+            CreateTemplate("mid_healer", "Midgard Healer", eRealm.Midgard, eCharacterClass.Healer, MimicRole.Healer | MimicRole.Support | MimicRole.CrowdControl),
+            CreateTemplate("mid_mauler", "Midgard Mauler", eRealm.Midgard, eCharacterClass.MaulerMid, MimicRole.Tank | MimicRole.Support),
+
+            // Hibernia
+            CreateTemplate("hib_hero", "Hibernia Hero", eRealm.Hibernia, eCharacterClass.Hero, MimicRole.Tank | MimicRole.DamageDealer),
+            CreateTemplate("hib_champion", "Hibernia Champion", eRealm.Hibernia, eCharacterClass.Champion, MimicRole.Tank | MimicRole.Support),
+            CreateTemplate("hib_blademaster", "Hibernia Blademaster", eRealm.Hibernia, eCharacterClass.Blademaster, MimicRole.DamageDealer),
+            CreateTemplate("hib_ranger", "Hibernia Ranger", eRealm.Hibernia, eCharacterClass.Ranger, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("hib_nightshade", "Hibernia Nightshade", eRealm.Hibernia, eCharacterClass.Nightshade, MimicRole.DamageDealer | MimicRole.Scout),
+            CreateTemplate("hib_valewalker", "Hibernia Valewalker", eRealm.Hibernia, eCharacterClass.Valewalker, MimicRole.DamageDealer | MimicRole.Support),
+            CreateTemplate("hib_vampiir", "Hibernia Vampiir", eRealm.Hibernia, eCharacterClass.Vampiir, MimicRole.DamageDealer),
+            CreateTemplate("hib_druid", "Hibernia Druid", eRealm.Hibernia, eCharacterClass.Druid, MimicRole.Healer | MimicRole.Support),
+            CreateTemplate("hib_bard", "Hibernia Bard", eRealm.Hibernia, eCharacterClass.Bard, MimicRole.Support | MimicRole.CrowdControl | MimicRole.Scout),
+            CreateTemplate("hib_warden", "Hibernia Warden", eRealm.Hibernia, eCharacterClass.Warden, MimicRole.Tank | MimicRole.Support),
+            CreateTemplate("hib_mentalist", "Hibernia Mentalist", eRealm.Hibernia, eCharacterClass.Mentalist, MimicRole.Healer | MimicRole.Support | MimicRole.CrowdControl),
+            CreateTemplate("hib_eldritch", "Hibernia Eldritch", eRealm.Hibernia, eCharacterClass.Eldritch, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("hib_enchanter", "Hibernia Enchanter", eRealm.Hibernia, eCharacterClass.Enchanter, MimicRole.DamageDealer | MimicRole.Support),
+            CreateTemplate("hib_animist", "Hibernia Animist", eRealm.Hibernia, eCharacterClass.Animist, MimicRole.DamageDealer | MimicRole.Support),
+            CreateTemplate("hib_bainshee", "Hibernia Bainshee", eRealm.Hibernia, eCharacterClass.Bainshee, MimicRole.CrowdControl | MimicRole.DamageDealer),
+            CreateTemplate("hib_mauler", "Hibernia Mauler", eRealm.Hibernia, eCharacterClass.MaulerHib, MimicRole.Tank | MimicRole.Support)
         };
+
+        private const byte DefaultMinimumLevel = 5;
+        private const byte DefaultMaximumLevel = 50;
+
+        private static MimicTemplate CreateTemplate(string id, string displayName, eRealm realm, eCharacterClass characterClass, MimicRole role)
+        {
+            return new MimicTemplate(id, displayName, realm, characterClass, GetModelId(realm, role), role, DefaultMinimumLevel, DefaultMaximumLevel);
+        }
+
+        private static ushort GetModelId(eRealm realm, MimicRole role)
+        {
+            bool prefersRobes = role.HasFlag(MimicRole.Healer) || role.HasFlag(MimicRole.CrowdControl) || (role.HasFlag(MimicRole.Support) && !role.HasFlag(MimicRole.Tank));
+
+            return realm switch
+            {
+                eRealm.Albion => prefersRobes ? (ushort)183 : (ushort)49,
+                eRealm.Midgard => prefersRobes ? (ushort)179 : (ushort)144,
+                eRealm.Hibernia => prefersRobes ? (ushort)188 : (ushort)190,
+                _ => (ushort)49
+            };
+        }
 
         private static readonly ConcurrentDictionary<GamePlayer, MimicGroupState> _groupStates = new();
         private static readonly ConcurrentDictionary<string, MimicNPC> _activeMimics = new();
@@ -73,7 +139,8 @@ namespace DOL.GS.Mimic
                 Heading = player.Heading
             };
 
-            MimicLoadoutBuilder.Configure(mimic);
+            mimic.AssignRole(template.DefaultRole);
+            MimicLoadoutBuilder.Configure(mimic, template.DefaultRole);
 
             if (!mimic.AddToWorld())
                 throw new InvalidOperationException("Unable to add mimic to world.");
@@ -84,7 +151,7 @@ namespace DOL.GS.Mimic
             groupState.AddMember(mimic);
             _activeMimics[mimic.InternalID] = mimic;
 
-            player.Out.SendMessage($"{mimic.Name} has been summoned at level {mimic.Level}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            player.Out.SendMessage($"{mimic.Name} has been summoned at level {mimic.Level}. Role: {MimicRoleInfo.ToDisplayString(mimic.Role)}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
             return mimic;
         }
 
@@ -174,11 +241,18 @@ namespace DOL.GS.Mimic
         public static void AssignRole(MimicNPC mimic, MimicRole role)
         {
             mimic.AssignRole(role);
+            AnnounceRoleChange(mimic);
         }
 
         public static void GuardTarget(MimicNPC mimic, GameLiving? target)
         {
             mimic.SetGuardTarget(target);
+        }
+
+        private static void AnnounceRoleChange(MimicNPC mimic)
+        {
+            GamePlayer owner = mimic.Owner;
+            owner.Out.SendMessage($"{mimic.Name} role set to {MimicRoleInfo.ToDisplayString(mimic.Role)}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
         }
 
         public static void SetCamp(GamePlayer player, Point3D location, int aggroRange, ConColor filter)

--- a/GameServer/mimic/MimicNPC.cs
+++ b/GameServer/mimic/MimicNPC.cs
@@ -37,6 +37,7 @@ namespace DOL.GS.Mimic
         public void AssignRole(MimicRole role)
         {
             Role = role;
+            _brain.OnRoleChanged(role);
         }
 
         public void SetPreventCombat(bool value)

--- a/GameServer/mimic/MimicRole.cs
+++ b/GameServer/mimic/MimicRole.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DOL.GS.Mimic
 {
@@ -10,6 +12,144 @@ namespace DOL.GS.Mimic
         Puller = 1 << 1,
         Tank = 1 << 2,
         CrowdControl = 1 << 3,
-        Assist = 1 << 4
+        Assist = 1 << 4,
+        Healer = 1 << 5,
+        Support = 1 << 6,
+        DamageDealer = 1 << 7,
+        Scout = 1 << 8
+    }
+
+    public static class MimicRoleInfo
+    {
+        private static readonly (string Alias, MimicRole Role)[] _aliases =
+        {
+            ("leader", MimicRole.Leader),
+            ("puller", MimicRole.Puller),
+            ("tank", MimicRole.Tank),
+            ("cc", MimicRole.CrowdControl),
+            ("crowdcontrol", MimicRole.CrowdControl),
+            ("assist", MimicRole.Assist),
+            ("healer", MimicRole.Healer),
+            ("heal", MimicRole.Healer),
+            ("support", MimicRole.Support),
+            ("dps", MimicRole.DamageDealer),
+            ("damage", MimicRole.DamageDealer),
+            ("damagedealer", MimicRole.DamageDealer),
+            ("scout", MimicRole.Scout)
+        };
+
+        private static readonly MimicRole[] _flagOrder =
+        {
+            MimicRole.Leader,
+            MimicRole.Puller,
+            MimicRole.Tank,
+            MimicRole.CrowdControl,
+            MimicRole.Assist,
+            MimicRole.Healer,
+            MimicRole.Support,
+            MimicRole.DamageDealer,
+            MimicRole.Scout
+        };
+
+        public static bool TryParse(string value, out MimicRole role)
+        {
+            role = MimicRole.None;
+
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            string[] tokens = value.Split(new[] { ',', '+', '|', '/', '\\', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string token in tokens)
+            {
+                string normalized = token.Trim().ToLowerInvariant();
+                MimicRole? match = null;
+
+                foreach ((string Alias, MimicRole Role) entry in _aliases)
+                {
+                    if (entry.Alias.Equals(normalized, StringComparison.Ordinal))
+                    {
+                        match = entry.Role;
+                        break;
+                    }
+                }
+
+                if (match == null)
+                {
+                    if (Enum.TryParse(normalized, true, out MimicRole parsed) && parsed != MimicRole.None)
+                        match = parsed;
+                }
+
+                if (match == null)
+                {
+                    role = MimicRole.None;
+                    return false;
+                }
+
+                role |= match.Value;
+            }
+
+            return role != MimicRole.None;
+        }
+
+        public static string GetSyntax()
+        {
+            return string.Join('|', _flagOrder
+                .Where(flag => flag != MimicRole.None)
+                .Select(ToCommandName));
+        }
+
+        public static string ToDisplayString(MimicRole role)
+        {
+            if (role == MimicRole.None)
+                return "None";
+
+            List<string> parts = new();
+
+            foreach (MimicRole flag in _flagOrder)
+            {
+                if (flag == MimicRole.None)
+                    continue;
+
+                if (role.HasFlag(flag))
+                    parts.Add(ToDisplayName(flag));
+            }
+
+            return parts.Count > 0 ? string.Join(", ", parts) : "None";
+        }
+
+        private static string ToDisplayName(MimicRole role)
+        {
+            return role switch
+            {
+                MimicRole.Leader => "Leader",
+                MimicRole.Puller => "Puller",
+                MimicRole.Tank => "Tank",
+                MimicRole.CrowdControl => "Crowd Control",
+                MimicRole.Assist => "Assist",
+                MimicRole.Healer => "Healer",
+                MimicRole.Support => "Support",
+                MimicRole.DamageDealer => "Damage Dealer",
+                MimicRole.Scout => "Scout",
+                _ => role.ToString()
+            };
+        }
+
+        private static string ToCommandName(MimicRole role)
+        {
+            return role switch
+            {
+                MimicRole.Leader => "leader",
+                MimicRole.Puller => "puller",
+                MimicRole.Tank => "tank",
+                MimicRole.CrowdControl => "cc",
+                MimicRole.Assist => "assist",
+                MimicRole.Healer => "healer",
+                MimicRole.Support => "support",
+                MimicRole.DamageDealer => "dps",
+                MimicRole.Scout => "scout",
+                _ => role.ToString().ToLowerInvariant()
+            };
+        }
     }
 }

--- a/GameServer/mimic/MimicTemplate.cs
+++ b/GameServer/mimic/MimicTemplate.cs
@@ -10,16 +10,18 @@ namespace DOL.GS.Mimic
         public eRealm Realm { get; }
         public eCharacterClass CharacterClass { get; }
         public ushort ModelId { get; }
+        public MimicRole DefaultRole { get; }
         public byte MinimumLevel { get; }
         public byte MaximumLevel { get; }
 
-        public MimicTemplate(string id, string displayName, eRealm realm, eCharacterClass characterClass, ushort modelId, byte minLevel, byte maxLevel)
+        public MimicTemplate(string id, string displayName, eRealm realm, eCharacterClass characterClass, ushort modelId, MimicRole defaultRole, byte minLevel, byte maxLevel)
         {
             Id = id;
             DisplayName = displayName;
             Realm = realm;
             CharacterClass = characterClass;
             ModelId = modelId;
+            DefaultRole = defaultRole;
             MinimumLevel = minLevel;
             MaximumLevel = maxLevel;
         }


### PR DESCRIPTION
## Summary
- implement role-aware behaviors in the mimic brain including healing, scouting, tanking, and crowd-control routines with chat feedback
- expand the mimic template roster to cover Dark Age of Camelot 1.127e classes and assign default roles with matching loadouts
- update player commands and loadouts to surface role information and support the richer role set

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6fa36d49c832fba770e83d214ba6b