### PR TITLE
Improve mimic role parsing and loadout updates

### DIFF
--- a/GameServer/commands/playercommands/mrole.cs
+++ b/GameServer/commands/playercommands/mrole.cs
@@ -21,6 +21,7 @@ namespace DOL.GS.Commands
             {
                 DisplaySyntax(client);
                 DisplayMessage(client, $"Available roles: {MimicRoleInfo.GetSyntax()}.");
+                DisplayRoleSummaries(client);
                 return;
             }
 
@@ -28,6 +29,7 @@ namespace DOL.GS.Commands
             if (!MimicRoleInfo.TryParse(requested, out MimicRole role))
             {
                 DisplayMessage(client, $"Unknown role. Available roles: {MimicRoleInfo.GetSyntax()}.");
+                DisplayRoleSummaries(client);
                 return;
             }
 
@@ -48,6 +50,14 @@ namespace DOL.GS.Commands
                 return mimic;
 
             return null;
+        }
+
+        private static void DisplayRoleSummaries(GameClient client)
+        {
+            foreach (string summary in MimicRoleInfo.GetRoleSummaries())
+                DisplayMessage(client, summary);
+
+            DisplayMessage(client, "Combine roles with commas, spaces, or slashes (e.g. /mrole healer support).");
         }
 
     }

--- a/GameServer/mimic/MimicManager.cs
+++ b/GameServer/mimic/MimicManager.cs
@@ -140,7 +140,6 @@ namespace DOL.GS.Mimic
             };
 
             mimic.AssignRole(template.DefaultRole);
-            MimicLoadoutBuilder.Configure(mimic, template.DefaultRole);
 
             if (!mimic.AddToWorld())
                 throw new InvalidOperationException("Unable to add mimic to world.");

--- a/GameServer/mimic/MimicNPC.cs
+++ b/GameServer/mimic/MimicNPC.cs
@@ -38,6 +38,7 @@ namespace DOL.GS.Mimic
         {
             Role = role;
             _brain.OnRoleChanged(role);
+            MimicLoadoutBuilder.Configure(this, role);
         }
 
         public void SetPreventCombat(bool value)


### PR DESCRIPTION
## Summary
- enrich mimic role metadata with descriptive help text and more forgiving alias parsing
- show detailed role summaries in the /mrole command output and refresh mimic loadouts whenever roles change

## Testing
- dotnet build DOLLinux.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68d7164a1624832fbe83c7b7d606e703