### PR TITLE
Fix mimic build issues

### DIFF
--- a/GameServer/ai/brain/Mimic/MimicBrain.cs
+++ b/GameServer/ai/brain/Mimic/MimicBrain.cs
@@ -554,7 +554,7 @@ namespace DOL.GS.Mimic
 
         private static bool IsCrowdControlSpell(Spell spell)
         {
-            return spell.SpellType is eSpellType.Mesmerize or eSpellType.Root or eSpellType.Stun or eSpellType.DamageSpeedDecrease;
+            return spell.SpellType is eSpellType.Mesmerize or eSpellType.SpeedDecrease or eSpellType.Stun or eSpellType.DamageSpeedDecrease;
         }
 
         private GameLiving? FindCrowdControlTarget(Spell spell)

--- a/GameServer/commands/playercommands/mrole.cs
+++ b/GameServer/commands/playercommands/mrole.cs
@@ -52,7 +52,7 @@ namespace DOL.GS.Commands
             return null;
         }
 
-        private static void DisplayRoleSummaries(GameClient client)
+        private void DisplayRoleSummaries(GameClient client)
         {
             foreach (string summary in MimicRoleInfo.GetRoleSummaries())
                 DisplayMessage(client, summary);

--- a/GameServer/mimic/MimicLoadoutBuilder.cs
+++ b/GameServer/mimic/MimicLoadoutBuilder.cs
@@ -243,7 +243,7 @@ namespace DOL.GS.Mimic
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Value = Math.Round(80 + mimic.Level * scaling, 1);
             return spell;
         }
@@ -260,7 +260,7 @@ namespace DOL.GS.Mimic
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Value = Math.Round(60 + mimic.Level * scaling, 1);
             return spell;
         }
@@ -279,7 +279,7 @@ namespace DOL.GS.Mimic
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Value = Math.Round(12 + mimic.Level * 1.4, 1);
             return spell;
         }
@@ -298,7 +298,7 @@ namespace DOL.GS.Mimic
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Value = type == eSpellType.PowerRegenBuff
                 ? Math.Round(3 + mimic.Level * 0.25, 1)
                 : Math.Round(12 + mimic.Level * 1.1, 1);
@@ -307,26 +307,25 @@ namespace DOL.GS.Mimic
 
         private static Spell CreateDamageSpell(MimicNPC mimic, SupportArchetype archetype)
         {
-            Spell spell = CloneBaseSpell("mimic_support_smite", () =>
+            Spell spell = CloneBaseSpell($"mimic_support_smite_{archetype}", () =>
             {
                 DbSpell db = CreateBaseSpell("Mimic Smite", SmiteSpellId, eSpellType.DirectDamage, eSpellTarget.ENEMY, 1500, 12, 2.8, 0, 717);
                 db.Description = "A modest ranged smite used to assist the group without diving into melee.";
                 db.SpellGroup = 9150;
                 db.EffectGroup = 9150;
                 db.Damage = 150;
-                db.DamageType = (int)eDamageType.Energy;
+                db.DamageType = archetype switch
+                {
+                    SupportArchetype.Albion => (int)eDamageType.Energy,
+                    SupportArchetype.Midgard => (int)eDamageType.Spirit,
+                    SupportArchetype.Hibernia => (int)eDamageType.Heat,
+                    _ => (int)eDamageType.Energy
+                };
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Damage = Math.Round(50 + mimic.Level * 2.2, 1);
-            spell.DamageType = archetype switch
-            {
-                SupportArchetype.Albion => (int)eDamageType.Energy,
-                SupportArchetype.Midgard => (int)eDamageType.Spirit,
-                SupportArchetype.Hibernia => (int)eDamageType.Heat,
-                _ => (int)eDamageType.Energy
-            };
 
             return spell;
         }
@@ -335,7 +334,7 @@ namespace DOL.GS.Mimic
         {
             Spell spell = CloneBaseSpell($"mimic_support_root_{archetype}", () =>
             {
-                DbSpell db = CreateBaseSpell("Mimic Entrapment", EntrapmentSpellId + (int)archetype, eSpellType.Root, eSpellTarget.ENEMY, 1500, 12, 2.8, 15, 716);
+                DbSpell db = CreateBaseSpell("Mimic Entrapment", EntrapmentSpellId + (int)archetype, eSpellType.SpeedDecrease, eSpellTarget.ENEMY, 1500, 12, 2.8, 15, 716);
                 db.Description = "A binding spell that roots an enemy in place to protect the group.";
                 db.SpellGroup = 9155 + (int)archetype;
                 db.EffectGroup = db.SpellGroup;
@@ -343,7 +342,7 @@ namespace DOL.GS.Mimic
                 return new Spell(db, 50);
             });
 
-            spell.Level = (byte)Math.Clamp(mimic.Level, 1, byte.MaxValue);
+            spell.Level = (byte)Math.Clamp(mimic.Level, (byte)1, byte.MaxValue);
             spell.Duration = (int)Math.Clamp(10 + mimic.Level * 0.4, 12, 30);
             return spell;
         }


### PR DESCRIPTION
## Summary
- disambiguate Math.Clamp calls when configuring mimic spells
- ensure mimic crowd control uses the correct spell type and crowd control detection
- allow mimic role command helper to use instance messaging helpers and configure archetype-specific damage types

## Testing
- `dotnet build DOLLinux.sln /p:WarningLevel=0` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d73c5d9c1c832fbe79d7508f72bed5