### PR TITLE
Fix CoreServer config copy

### DIFF
--- a/CoreServer/CoreServer.csproj
+++ b/CoreServer/CoreServer.csproj
@@ -47,10 +47,10 @@
         <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="9.0.5" />
         <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.5" />
         <ProjectReference Include="..\GameServer\GameServer.csproj" Name="GameServer" />
-        <Content Include=".\config\serverconfig.xml">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Content Include="config\serverconfig.example.xml">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <TargetPath>config/serverconfig.xml</TargetPath>
         </Content>
-        <Content Include="config\serverconfig.example.xml" />
     </ItemGroup>
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
## Summary
- update CoreServer project so the example server configuration is copied to the output as the default `serverconfig.xml`

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d73d9325cc832fa961adf138a513ce