### PR TITLE
Track player attack mode for mimic assists

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -705,6 +705,9 @@ namespace DOL.GS
             }
 
             AttackState = true;
+
+            if (owner is GamePlayer playerOwner)
+                playerOwner.IsInAttackMode = true;
             return true;
         }
 
@@ -781,6 +784,8 @@ namespace DOL.GS
             attackAction.OnStopAttack();
             bool oldAttackState = AttackState;
             AttackState = false;
+            if (owner is GamePlayer playerOwner)
+                playerOwner.IsInAttackMode = false;
             owner.CancelEngageEffect();
             owner.styleComponent.NextCombatStyle = null;
             owner.styleComponent.NextCombatBackupStyle = null;

--- a/GameServer/ai/brain/Mimic/MimicBrain.cs
+++ b/GameServer/ai/brain/Mimic/MimicBrain.cs
@@ -316,8 +316,15 @@ namespace DOL.GS.Mimic
 
         private static bool OwnerIsAggressive(GameLiving owner)
         {
-            if (owner.IsAttacking)
+            if (owner is GamePlayer player)
+            {
+                if (player.IsInAttackMode)
+                    return true;
+            }
+            else if (owner.IsAttacking)
+            {
                 return true;
+            }
 
             ISpellHandler? spellHandler = owner.CurrentSpellHandler;
             return spellHandler != null && spellHandler.Spell.Target == eSpellTarget.ENEMY;

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -128,7 +128,17 @@ namespace DOL.GS
         private ArrayList m_mlSteps = new ArrayList();
 
         private bool m_gmStealthed = false;
+        private bool _isInAttackMode;
         public bool GMStealthed { get { return m_gmStealthed; } set { m_gmStealthed = value; } }
+
+        /// <summary>
+        /// Tracks whether the player has toggled attack mode on the client.
+        /// </summary>
+        public bool IsInAttackMode
+        {
+            get => _isInAttackMode;
+            internal set => _isInAttackMode = value;
+        }
 
         /// <summary>
         /// Can this living accept any item regardless of tradable or droppable?

--- a/GameServer/packets/Client/168/PlayerTargetHandler.cs
+++ b/GameServer/packets/Client/168/PlayerTargetHandler.cs
@@ -15,10 +15,10 @@ namespace DOL.GS.PacketHandler.Client.v168
              * 0x0001 = players attack mode bit (not targets!)
              */
 
-            ChangeTarget(client.Player, targetId, (flags & (0x4000 | 0x2000)) != 0, (flags & 0x8000) != 0);
+            ChangeTarget(client.Player, targetId, (flags & (0x4000 | 0x2000)) != 0, (flags & 0x8000) != 0, (flags & 0x0001) != 0);
         }
 
-        private static void ChangeTarget(GamePlayer actionSource, ushort newTargetId, bool targetInView, bool examineTarget)
+        private static void ChangeTarget(GamePlayer actionSource, ushort newTargetId, bool targetInView, bool examineTarget, bool isAttackMode)
         {
             GameObject target = actionSource.CurrentRegion.GetObject(newTargetId);
 
@@ -30,6 +30,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
             actionSource.TargetObject = target;
             actionSource.TargetInView = targetInView;
+            actionSource.IsInAttackMode = isAttackMode;
 
             if (target != null)
             {


### PR DESCRIPTION
## Summary
- track the player's attack mode on the server when changing targets or starting/stopping attacks
- expose the attack mode state to mimics so they only assist when the owner is actually engaging or casting offensively

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7551df34c832fac6135ebb1c59431