### PR TITLE
Fix duplicate GamePlayer handling in StopAttack

### DIFF
--- a/GameServer/ECS-Components/AttackComponent.cs
+++ b/GameServer/ECS-Components/AttackComponent.cs
@@ -785,13 +785,9 @@ namespace DOL.GS
             bool oldAttackState = AttackState;
             AttackState = false;
             if (owner is GamePlayer playerOwner)
-                playerOwner.IsInAttackMode = false;
-            owner.CancelEngageEffect();
-            owner.styleComponent.NextCombatStyle = null;
-            owner.styleComponent.NextCombatBackupStyle = null;
-
-            if (owner is GamePlayer playerOwner)
             {
+                playerOwner.IsInAttackMode = false;
+
                 if (playerOwner.IsAlive && oldAttackState)
                     playerOwner.Out.SendAttackMode(AttackState);
             }
@@ -806,6 +802,10 @@ namespace DOL.GS
                     npcOwner.SwitchWeapon(eActiveWeaponSlot.Distance);
                 }
             }
+
+            owner.CancelEngageEffect();
+            owner.styleComponent.NextCombatStyle = null;
+            owner.styleComponent.NextCombatBackupStyle = null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- prevent declaring the `playerOwner` local twice when stopping an attack
- ensure the player-specific attack mode logic still runs before cleaning up shared state

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d75acd7130832f8ab62f44510b2287