### PR TITLE
Fix loot distribution when mimics secure kills

### DIFF
--- a/GameServer/serverrules/AbstractServerRules.cs
+++ b/GameServer/serverrules/AbstractServerRules.cs
@@ -7,6 +7,7 @@ using DOL.Database;
 using DOL.Events;
 using DOL.GS.Housing;
 using DOL.GS.Keeps;
+using DOL.GS.Mimic;
 using DOL.GS.PacketHandler;
 using DOL.GS.ServerProperties;
 using DOL.Language;
@@ -1121,12 +1122,24 @@ namespace DOL.GS.ServerRules
                 {
                     totalDamage += pair.Value; // Should be done before excluding players.
 
+                    GameLiving conLiving = pair.Key;
+                    GamePlayer player = pair.Key as GamePlayer;
+
+                    if (pair.Key is MimicNPC mimic)
+                    {
+                        player = mimic.Owner;
+                        if (player == null)
+                            continue;
+
+                        conLiving = player;
+                    }
+
                     // If the killed NPC is gray to any of the entities, or if a guard is involved, don't give any XP, drop any loot, change faction relations, etc.
-                    if (pair.Key.IsObjectGreyCon(killedNpc) || pair.Key is GameGuard)
+                    if (conLiving.IsObjectGreyCon(killedNpc) || conLiving is GameGuard)
                         return false;
 
                     // We only care about players in range.
-                    if (pair.Key is not GamePlayer player || player.ObjectState is not GameObject.eObjectState.Active || !player.IsWithinRadius(killedNpc, WorldMgr.MAX_EXPFORKILL_DISTANCE))
+                    if (player == null || player.ObjectState is not GameObject.eObjectState.Active || !player.IsWithinRadius(killedNpc, WorldMgr.MAX_EXPFORKILL_DISTANCE))
                         continue;
 
                     ProcessDamage(player, pair.Value, player, mostDamagingPlayer, playerCountAndDamage);


### PR DESCRIPTION
## Summary
- credit mimic damage to their owning player when processing NPC kill rewards
- ensure loot eligibility checks run against the player so drops still go to real group members

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9f1da22c4832fb8ed9d33e450137b