### PR TITLE
Restore player loot drops when mimics deal damage

### DIFF
--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -10,6 +10,7 @@ using DOL.Database;
 using DOL.Events;
 using DOL.GS.Effects;
 using DOL.GS.Keeps;
+using DOL.GS.Mimic;
 using DOL.GS.PacketHandler;
 using DOL.GS.PropertyCalc;
 using DOL.GS.RealmAbilities;
@@ -1846,13 +1847,16 @@ namespace DOL.GS
 		/// </summary>
 		/// <param name="xpGainer">the xp gaining object</param>
 		/// <param name="damageAmount">the amount of damage, float because for groups it can be split</param>
-		public virtual void AddXPGainer(GameLiving xpGainer, double damageAmount)
-		{
-			lock (XpGainersLock)
-			{
-				m_xpGainers[xpGainer] = m_xpGainers.TryGetValue(xpGainer, out double value) ? value + damageAmount : damageAmount;
-			}
-		}
+                public virtual void AddXPGainer(GameLiving xpGainer, double damageAmount)
+                {
+                        if (xpGainer is MimicNPC mimic && mimic.Owner is GamePlayer mimicOwner)
+                                xpGainer = mimicOwner;
+
+                        lock (XpGainersLock)
+                        {
+                                m_xpGainers[xpGainer] = m_xpGainers.TryGetValue(xpGainer, out double value) ? value + damageAmount : damageAmount;
+                        }
+                }
 
 		// Temporary locks to help a little with the race condition mess around health, endurance, and power.
 		// This is mainly helpful for concurrent heals / regen ticks. Attacks don't do damage via `ChangeHealth`.


### PR DESCRIPTION
## Summary
- map mimic XP gainer entries to their owning players so reward logic always sees real players
- drop the mimic-specific damage handling from server rules now that XP gainers are normalized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9f1da22c4832fb8ed9d33e450137b